### PR TITLE
Update to PureScript 0.15.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .spago/
 output/
 bower_components/
+.psc-ide-port

--- a/bower.json
+++ b/bower.json
@@ -1,19 +1,14 @@
 {
-    "name": "purescript-undefined-or",
-    "license": [
-        "MIT"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/d86leader/purescript-undefined-or"
-    },
-    "ignore": [
-        "**/.*",
-        "node_modules",
-        "bower_components",
-        "output"
-    ],
-    "dependencies": {
-        "purescript-maybe": "^v4.0.1"
-    }
+  "name": "purescript-undefined-or",
+  "license": ["MIT"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/d86leader/purescript-undefined-or"
+  },
+  "ignore": ["**/.*", "node_modules", "bower_components", "output"],
+  "dependencies": {
+    "purescript-prelude": "^v6.0.0",
+    "purescript-maybe": "^v6.0.0",
+    "purescript-control": "^v6.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -7,16 +7,17 @@
     "type": "git",
     "url": "purescript-undefined-or"
   },
-  "keywords": [
-    "purescript",
-    "ffi"
-  ],
+  "scripts": {
+    "test": "spago -x test.spago.dhall test",
+    "build": "spago build"
+  },
+  "keywords": ["purescript", "ffi"],
   "author": "d86leader",
   "license": "MIT",
   "devDependencies": {
-    "purescript": "^0.13.6",
-    "spago": "^0.14.0",
-    "pulp": "^14.0.0",
-    "bower": "^1.8.8"
+    "purescript": "^0.15.4",
+    "spago": "^0.20.9",
+    "pulp": "^16.0.2",
+    "bower": "^1.8.14"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,5 +1,6 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.6-20200404/packages.dhall sha256:f239f2e215d0cbd5c203307701748581938f74c4c78f4aeffa32c11c131ef7b6
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.4-20220816/packages.dhall
+        sha256:8b4467b4b5041914f9b765779c8936d6d4c230b1f60eb64f6269c71812fd7e98
 
 let overrides = {=}
 

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,12 +1,7 @@
-{ sources =
-    [ "src/**/*.purs" ]
-, name =
-    "purescript-undefined-or"
-, dependencies =
-    [ "maybe"
-    ]
-, packages =
-    ./packages.dhall
+{ sources = [ "src/**/*.purs" ]
+, name = "purescript-undefined-or"
+, dependencies = [ "control", "maybe", "prelude" ]
+, packages = ./packages.dhall
 , license = "MIT"
 , repository = "https://github.com/d86leader/purescript-undefined-or"
 }

--- a/src/Data/UndefinedOr.js
+++ b/src/Data/UndefinedOr.js
@@ -1,7 +1,5 @@
-"use strict";
-
-exports.isUndefined = function(val) {
-    return val == undefined;
+export function isUndefined (val) {
+  return val == undefined
 }
 
-exports.undefinedVal = undefined;
+export const undefinedVal = undefined

--- a/test.spago.dhall
+++ b/test.spago.dhall
@@ -1,6 +1,7 @@
 let conf = ./spago.dhall
 let deps =
     [ "effect"
+    , "aff"
     , "spec"
     ]
 

--- a/test/Main.js
+++ b/test/Main.js
@@ -1,3 +1,1 @@
-"use strict";
-
-exports.dict = {"yes": "yes"};
+export const dict = { yes: 'yes' }


### PR DESCRIPTION
Hi,

as someone asked on Discourse I thought it'd be a good idea to upgrade this package.

This PR should do so:

- updated npm dependencies to latest version
- upgrades package-set to latest version
- added missing dependencies to spago.dhall
- adjusted bower versions
- converted FFI files to ES6-modules
- added npm scripts for build and testing